### PR TITLE
Fix wrong types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,8 +37,8 @@ declare module 'unb-api' {
     }
 
     export type Balance = {
-        cash?: number,
-        bank?: number
+        cash?: number | string,
+        bank?: number | string
     }
 
     export type Options = {


### PR DESCRIPTION
In the JSDoc it specifies the balance may be a number or a string, but the typings only specify number.